### PR TITLE
Added german translations for glossary arrow and more

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -30,7 +30,8 @@
         "divider": "Trennlinie",
         "annotation": "Objekt",
         "callout": "Callout",
-        "ctrl": "Strg"
+        "ctrl": "Strg",
+        "arrow": "Pfeil"
     },
 	"action": {
         "file": {
@@ -178,7 +179,7 @@
                     "name": "100%"
                 },
                 "fit": {
-                    "name": "Maximieren"
+                    "name": "Einpassen"
                 },
                 "in": {
                     "name": "Vergrößern"


### PR DESCRIPTION
Again: Updated the translation. I added the German word for glossary.arrow and changed the translation for zoom to fit.